### PR TITLE
Update to use Popper 2 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Popper.js allows you to dynamically align a div, e.g. a tooltip, to another elem
 ## Dependencies
 
  * Cytoscape.js ^3.2.0
- * Popper.js ^2.4.4
+ * Popper.js ^2.0.0
 
 
 ## Usage instructions
@@ -52,16 +52,15 @@ require(['cytoscape', 'cytoscape-popper'], function( cytoscape, popper ){
 
 Plain HTML/JS has the extension registered for you automatically, because no `require()` is needed.
 
-
 ## API
 
 This extension exposes two functions, `popper()` and `popperRef()`.  These functions are defined for both the core and for elements, so you can call `cy.popper()` or `ele.popper()` for example.
 
 Each function takes an options object, as follows:
 
-`cy.popper( options )` or `ele.popper( options )` : Get a [Popper Instance](https://popper.js.org/docs/v2/constructors/#createpopper) for the specified core Cytoscape instance or the specified element.  This is useful for positioning a div relative to or on top of a core instance or element.
+`cy.popper( options )` or `ele.popper( options )` : Get a [Popper Instance](https://popper.js.org/docs/v2/constructors/) for the specified core Cytoscape instance or the specified element.  This is useful for positioning a div relative to or on top of a core instance or element.
 
-`cy.popperRef( options )` or `ele.popperRef( options )` : Get a [Popper Virtual Element](https://popper.js.org/docs/v2/virtual-elements/) for the specified core Cytoscape instance or the specified element.  A Popper virtual element is useful only for positioning, as it represent the target rather than the content.  This is useful for cases where you want to `createPopper()` manually or where you need to pass a `popperRef` object to another library like Tippy.js.
+`cy.popperRef( options )` or `ele.popperRef( options )` : Get a [Popper virtual element](https://popper.js.org/docs/v2/virtual-elements/) (aka `Popper reference object` in Popper v1) for the specified core Cytoscape instance or the specified element.  A Popper virtual element is useful only for positioning, as it represent the target rather than the content.  This is useful for cases where you want to create a new Popper instance manually via Popper constructor `createPopper()` or where you need to pass a `popperRef` object to another library like Tippy.js.
 
  - `options`
    - `content` : The HTML content of the popper.  May be a DOM `Element` reference or a function that returns one.
@@ -155,7 +154,6 @@ let ref = node.popperRef(); // used only for positioning
 // https://atomiks.github.io/tippyjs/v6/constructor/#target-types
 let dummyDomEle = document.createElement('div');
 
-// using tippy@^6.2.5
 let tip = new Tippy(dummyDomEle, { // tippy props:
    getReferenceClientRect: ref.getBoundingClientRect, // https://atomiks.github.io/tippyjs/v6/all-props/#getreferenceclientrect
    trigger: 'manual', // mandatory, we cause the tippy to show programmatically.
@@ -176,7 +174,10 @@ tip.show();
 
 Refer to [Tippy.js](https://atomiks.github.io/tippyjs/) documentation for more details.
 
+## v2 changes
+This version of cytoscape-popper has been updated to use Popper 2 and be compatible with Tippy 6. Thus, it is no longer compatible with Popper v1/Tippy v5. If your application needs Popper v1/Tippy v5, use the latest v1 version of cytoscape-popper instead. Cytoscape-popper v1 dependencies are Cytoscape.js ^3.2.0 and Popper.js ^1.12.0.
 
+The cytoscape-popper api has not changed in v2, but you may need to update your code if it references Popper/Tippy. See [Migrating to Popper 2](https://popper.js.org/docs/v2/migration-guide/) and [Tippy Migration Guide](https://github.com/atomiks/tippyjs/blob/master/MIGRATION_GUIDE.md#5x-to-6x).
 
 ## Build targets
 

--- a/demo-tippy.html
+++ b/demo-tippy.html
@@ -11,11 +11,10 @@
 	<!-- for testing with local version of cytoscape.js -->
 	<!--<script src="../cytoscape.js/build/cytoscape.js"></script>-->
 
-  <script src="https://unpkg.com/popper.js@1.16.0/dist/umd/popper.js"></script>
+	<script src="https://unpkg.com/@popperjs/core@2"></script>
 	<script src="cytoscape-popper.js"></script>
 
-	<script src="https://unpkg.com/tippy.js@5.2.1/dist/tippy-bundle.iife.min.js"></script>
-	<link rel="stylesheet" href="https://unpkg.com/tippy.js@5.2.1/dist/tippy.css" />
+	<script src="https://unpkg.com/tippy.js@6"></script>
 
 	<style>
 		body {
@@ -86,23 +85,15 @@
 			var b = cy.getElementById('b');
 			var ab = cy.getElementById('ab');
 
-			var makeTippy = function(node, text){
-				var ref = node.popperRef();
+			var makeTippy = function(ele, text){
+				var ref = ele.popperRef();
 
-				// unfortunately, a dummy element must be passed
-				// as tippy only accepts a dom element as the target
-				// https://github.com/atomiks/tippyjs/issues/661
+				// Since tippy constructor requires DOM element/elements, create a placeholder
 				var dummyDomEle = document.createElement('div');
 
 				var tip = tippy( dummyDomEle, {
-					onCreate: function(instance){ // mandatory
-						// patch the tippy's popper reference so positioning works
-						// https://atomiks.github.io/tippyjs/misc/#custom-position
-						instance.popperInstance.reference = ref;
-					},
-					lazy: false, // mandatory
+					getReferenceClientRect: ref.getBoundingClientRect,
 					trigger: 'manual', // mandatory
-
 					// dom element inside the tippy:
 					content: function(){ // function can be better for performance
 						var div = document.createElement('div');
@@ -111,13 +102,11 @@
 
 						return div;
 					},
-
 					// your own preferences:
 					arrow: true,
 					placement: 'bottom',
 					hideOnClick: false,
-					multiple: true,
-					sticky: true,
+					sticky: "reference",
 
 					// if interactive:
 					interactive: true,

--- a/demo.html
+++ b/demo.html
@@ -11,7 +11,7 @@
 	<!-- for testing with local version of cytoscape.js -->
 	<!--<script src="../cytoscape.js/build/cytoscape.js"></script>-->
 
-  <script src="https://unpkg.com/popper.js@1.16.0/dist/umd/popper.js"></script>
+  	<script src="https://unpkg.com/@popperjs/core@2"></script>
 	<script src="cytoscape-popper.js"></script>
 
 	<style>
@@ -103,7 +103,7 @@
 			});
 
 			var updateA = function(){
-				popperA.scheduleUpdate();
+				popperA.update();
 			};
 
 			a.on('position', updateA);
@@ -118,7 +118,7 @@
 			});
 
 			var updateAB = function(){
-				popperAB.scheduleUpdate();
+				popperAB.update();
 			};
 
 			ab.connectedNodes().on('position', updateAB);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@popperjs/core": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw=="
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -10300,11 +10305,6 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
-    },
-    "popper.js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
-      "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
     },
     "portfinder": {
       "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "cytoscape": "^3.2.0"
   },
   "dependencies": {
-    "@popperjs/core": "^2.4.4"
+    "@popperjs/core": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "cytoscape": "^3.2.0"
   },
   "dependencies": {
-    "@popperjs/core": "^2.6.0"
+    "@popperjs/core": "^2.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "cytoscape": "^3.2.0"
   },
   "dependencies": {
-    "popper.js": "^1.0.0"
+    "@popperjs/core": "^2.6.0"
   }
 }

--- a/src/core.js
+++ b/src/core.js
@@ -23,7 +23,7 @@ function createOptionsObject(target, opts) {
       h: 3,
     },
     renderedDimensions : () => ({w: 3, h: 3}),
-    redneredPosition : () => ({x : 0, y : 0}),
+    renderedPosition : () => ({x : 0, y : 0}),
     popper : {},
     cy : target
   };

--- a/src/popper.js
+++ b/src/popper.js
@@ -4,12 +4,7 @@ const { getContent } = require('./content');
 
 const popperDefaults = {};
 
-//Fix Popper.js webpack import conflict (Use .default if using webpack)
-let Popper = require('popper.js');
-let EsmWebpackPopper = Popper.default;
-if (EsmWebpackPopper != null && EsmWebpackPopper.Defaults != null) {
-  Popper = Popper.default;
-}
+const {createPopper} = require('@popperjs/core');
 
 // Create a new popper object for a core or element target
 function getPopper(target, opts) {
@@ -17,7 +12,7 @@ function getPopper(target, opts) {
   let content = getContent(target, opts.content);
   let popperOpts = assign({}, popperDefaults, opts.popper);
 
-  return new Popper(refObject, content, popperOpts);
+  return createPopper(refObject, content, popperOpts);
 }
 
 module.exports = { getPopper };

--- a/src/ref.js
+++ b/src/ref.js
@@ -1,23 +1,14 @@
 const { getBoundingBox } = require('./bb');
 
-// Create a popper reference object
-// https://popper.js.org/popper-documentation.html#referenceObject
+// Create a popper virtual element (aka popper v1 reference object)
+// https://popper.js.org/docs/v2/virtual-elements/
 function getRef(target, opts) {
-  let { renderedDimensions } = opts;
 
   //Define popper reference object and cy reference  object
   let refObject = {
     getBoundingClientRect: function() {
       return getBoundingBox(target, opts);
-    },
-
-    get clientWidth() {
-      return renderedDimensions(target).w;
-    },
-
-    get clientHeight() {
-      return renderedDimensions(target).h;
-    },
+    }
   };
 
   return refObject;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,10 +23,10 @@ let config = {
     ]
   },
   externals: {
-    "popper.js" : {
-      commonjs: "popper.js",
-      commonjs2: "popper.js",
-      amd: "popper.js",
+    "@popperjs/core" : {
+      commonjs: "@popperjs/core",
+      commonjs2: "@popperjs/core",
+      amd: "@popperjs/core",
       root: "Popper"
     }
   },


### PR DESCRIPTION
Updated to use Popper 2 (and thus Tippy 6). Fixed typo in core.js. This would be a breaking change from v1.x.