### PR TITLE
fix README.md floating-ui example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ function popperFactory(ref, content, opts) {
    }
 
    function update() {
-       computePosition(ref, content, opts).then(({x, y}) => {
+       computePosition(ref, content, popperOptions).then(({x, y}) => {
            Object.assign(content.style, {
                left: `${x}px`,
                top: `${y}px`,


### PR DESCRIPTION
It was using the user defined `opts` without the default `popperOptions` that were defined just above (that are overridden by the user options).